### PR TITLE
point flightdeck nodes in the most logical direction

### DIFF
--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/CargoLift.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/CargoLift.cfg
@@ -22,12 +22,12 @@ PART
 	}
 
 	// --- node definitions ---
-	node_attach = 5, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	node_attach = 5, 0.0, 0.0, 1, 0, 0, 1
 	node_stack_top = 0.0, 0.0, -5.0, 0, 0, -1, 3
 	node_stack_left = -5.0, 0.0, 0.0, -1, 0, 0, 3
 	node_stack_right = 5.0, 0.0, 0.0, 1, 0, 0, 3
-	node_stack_front = 0.0, 2.5, 0.0, 0.0, 1.0, 0.0, 3
-	node_stack_back = 0.0, -2.5, 0.0, 0.0, -1.0, 0.0, 3
+	node_stack_front = 0.0, 2.5, 0.0, 0.0, 1, 0, 3
+	node_stack_back = 0.0, -2.5, 0.0, 0.0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/FlightDeckFairing.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/FlightDeckFairing.cfg
@@ -21,8 +21,8 @@ PART
 	}
 
 	// --- node definitions ---
-	node_stack_flightDeckMount = 0.0, 0.0, 0.0, 0, 0, 1, 3
-	node_stack_top = 0.0, 0.0, 0.0, 0, 0, -1, 3
+	node_stack_flightDeckMount = 0.0, 0.0, 0.0, 0, 1, 0, 3
+	node_stack_top = 0.0, 0.0, 0.0, 0, 0, 1, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type1Extension.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type1Extension.cfg
@@ -23,16 +23,16 @@ PART
 	// --- node definitions ---
 	node_stack_Bottom = 0.0, 0.0, 0.125, 0, 0, 1, 3
 	node_stack_top = 0.0, 0.0, 0.0, 0, 0, -1, 3
-	node_stack_left = -5.0, 0, 0.0, 0, 0, -1, 3
-	node_stack_right = 5.0, 0, 0.0, 0, 0, -1, 3
-	node_stack_front = 0.0, 5, 0.0, 0.0, 0, -1, 3
-	node_stack_back = 0.0, -5, 0.0, 0.0, 0, -1, 3
+	node_stack_left = -5.0, 0, 0.0, -1, 0, 0, 3
+	node_stack_right = 5.0, 0, 0.0, 1, 0, 0, 3
+	node_stack_front = 0.0, 5, 0.0, 0, 1, 0, 3
+	node_stack_back = 0.0, -5, 0.0, 0, -1, 0, 3
 
 	node_stack_top2 = 0.0, 0.0, 0.0, 0, 0, 1, 3
-	node_stack_left2 = -5.0, 0, 0.0, 0, 0, 1, 3
-	node_stack_right2 = 5.0, 0, 0.0, 0, 0, 1, 3
-	node_stack_front2 = 0.0, 5, 0.0, 0.0, 0, 1, 3
-	node_stack_back2 = 0.0, -5, 0.0, 0.0, 0, 1, 3
+	node_stack_left2 = -5.0, 0.0, 0.0, -1, 0, 0, 3
+	node_stack_right2 = 5.0, 0.0, 0.0, 1, 0, 0, 3
+	node_stack_front2 = 0.0, 5.0, 0.0, 0, 1, 0, 3
+	node_stack_back2 = 0.0, -5.0, 0.0, 0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type2Extension.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type2Extension.cfg
@@ -23,16 +23,16 @@ PART
 	// --- node definitions ---
 	node_stack_Bottom = 0.0, 0.0, 0.125, 0, 0, 1, 3
 	node_stack_top = 0.0, 0.0, 0.0, 0, 0, -1, 3
-	node_stack_left = -5.0, 0, 0.0, 0, 0, -1, 3
-	node_stack_right = 5.0, 0, 0.0, 0, 0, -1, 3
-	node_stack_front = 0.0, 2.5, 0.0, 0.0, 0, -1, 3
-	node_stack_back = 0.0, -2.5, 0.0, 0.0, 0, -1, 3
+	node_stack_left = -5.0, 0.0, 0.0, -1, 0, 0, 3
+	node_stack_right = 5.0, 0.0, 0.0, 1, 0, 0, 3
+	node_stack_front = 0.0, 2.5, 0.0, 0, 1, 0, 3
+	node_stack_back = 0.0, -2.5, 0.0, 0, -1, 0, 3
 
 	node_stack_top2 = 0.0, 0.0, 0.0, 0, 0, 1, 3
-	node_stack_left2 = -5.0, 0, 0.0, 0, 0, 1, 3
-	node_stack_right2 = 5.0, 0, 0.0, 0, 0, 1, 3
-	node_stack_front2 = 0.0, 2.5, 0.0, 0.0, 0, 1, 3
-	node_stack_back2 = 0.0, -2.5, 0.0, 0.0, 0, 1, 3
+	node_stack_left2 = -5.0, 0.0, 0.0, -1, 0, 0, 3
+	node_stack_right2 = 5.0, 0.0, 0.0, 1, 0, 0, 3
+	node_stack_front2 = 0.0, 2.5, 0.0, 0, 1, 0, 3
+	node_stack_back2 = 0.0, -2.5, 0.0, 0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type3Extension.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type3Extension.cfg
@@ -21,8 +21,8 @@ PART
 	}
 
 	// --- node definitions ---
-	node_stack_back = 0.0, -2.5, 0.0, 0.0, 0, 1, 3
-	node_stack_back2 = 0.0, -2.5, 0.0, 0.0, 0, -1, 3
+	node_stack_back = 0.0, -2.5, 0.0, 0.0, -1, 0, 3
+	node_stack_back2 = 0.0, -2.5, 0.0, 0.0, 0, 1, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type4Extension.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type4Extension.cfg
@@ -21,10 +21,10 @@ PART
 	}
 
 	// --- node definitions ---
-	node_stack_front = 0, 0, 0.0, 0.0, 0, 1, 3
-	node_stack_front2 = 0, 0, 0.0, 0.0, 0, -1, 3
-	node_stack_back = -2.5, -2.5, 0.0, 0.0, 0, 1, 3
-	node_stack_back2 = -2.5, -2.5, 0.0, 0.0, 0, -1, 3
+	node_stack_front = 0.0, 0.0, 0.0, 1, 0, 0, 3
+	node_stack_front2 = 0.0, 0.0, 0.0, 0, 1, 0, 3
+	node_stack_back = -2.5, -2.5, 0.0, 0, -1, 0, 3
+	node_stack_back2 = -2.5, -2.5, 0.0, -1, 0, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type5Extension.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type5Extension.cfg
@@ -21,10 +21,10 @@ PART
 	}
 
 	// --- node definitions ---
-	node_stack_front = 0, 0, 0.0, 0.0, 0, 1, 3
-	node_stack_front2 = 0, 0, 0.0, 0.0, 0, -1, 3
-	node_stack_back = -1.25, -2.5, 0.0, 0.0, 0, 1, 3
-	node_stack_back2 = -1.25, -2.5, 0.0, 0.0, 0, -1, 3
+	node_stack_front = 0.0, 0.0, 0.0, 1, 0, 0, 3
+	node_stack_front2 = 0.0, 0.0, 0.0, 0, 1, 0, 3
+	node_stack_back = -1.25, -2.5, 0.0, 0, -1, 0, 3
+	node_stack_back2 = -1.25, -2.5, 0.0, -1, 0, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type6Extension.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/Type6Extension.cfg
@@ -23,12 +23,12 @@ PART
 	// --- node definitions ---
 	node_stack_Bottom = 0.0, 0.0, 0.125, 0, 0, 1, 3
 	node_stack_top = 0.0, 0.0, 0.0, 0, 0, -1, 3
-	node_stack_right = 5.0, 0, 0.0, 0, 0, -1, 3
-	node_stack_back = 0.0, -2.5, 0.0, 0.0, 0, -1, 3
+	node_stack_right = 5.0, 0.0, 0.0, 1, 0, 0, 3
+	node_stack_back = 0.0, -2.5, 0.0, 0, -1, 0, 3
 
 	node_stack_top2 = 0.0, 0.0, 0.0, 0, 0, 1, 3
-	node_stack_right2 = 5.0, 0, 0.0, 0, 0, 1, 3
-	node_stack_back2 = 0.0, -2.5, 0.0, 0.0, 0, 1, 3
+	node_stack_right2 = 5.0, 0, 0.0, 1, 0, 0, 3
+	node_stack_back2 = 0.0, -2.5, 0.0, 0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10AircraftElevator.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10AircraftElevator.cfg
@@ -22,10 +22,10 @@ PART
 
 	// --- node definitions ---
 	node_stack_flightDeckMount = 0.0, 0.0, -5.0, 0, 0, 1, 3
-	node_stack_left = -5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_right = 5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_front = 0.0, 5, -5.125, 0, 0, -1, 3
-	node_stack_back = 0.0, -5, -5.125, 0, 0, -1, 3
+	node_stack_left = -5.0, 0.0, -5.125, -1, 0, 0, 3
+	node_stack_right = 5.0, 0.0, -5.125, 1, 0, 0, 3
+	node_stack_front = 0.0, 5.0, -5.125, 0, 1, 0, 3
+	node_stack_back = 0.0, -5.0, -5.125, 0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10FlightDeck.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10FlightDeck.cfg
@@ -22,10 +22,10 @@ PART
 
 	// --- node definitions ---
 	node_stack_flightDeckMount = 0.0, 0.0, -5.0, 0, 0, 1, 3
-	node_stack_left = -5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_right = 5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_front = 0.0, 5, -5.125, 0, 0, -1, 3
-	node_stack_back = 0.0, -5, -5.125, 0, 0, -1, 3
+	node_stack_left = -5.0, 0.0, -5.125, -1, 0, 0, 3
+	node_stack_right = 5.0, 0.0, -5.125, 1, 0, 0, 3
+	node_stack_front = 0.0, 5.0, -5.125, 0, 1, 0, 3
+	node_stack_back = 0.0, -5.0, -5.125, 0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10HalfAircraftElevator.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10HalfAircraftElevator.cfg
@@ -22,10 +22,10 @@ PART
 
 	// --- node definitions ---
 	node_stack_flightDeckMount = 0.0, 0.0, -5.0, 0, 0, 1, 3
-	node_stack_left = -5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_right = 5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_front = 0.0, 5, -5.125, 0, 0, -1, 3
-	node_stack_back = 0.0, -5, -5.125, 0, 0, -1, 3
+	node_stack_left = -5.0, 0.0, -5.125, -1, 0, 0, 3
+	node_stack_right = 5.0, 0.0, -5.125, 1, 0, 0, 3
+	node_stack_front = 0.0, 5.0, -5.125, 0, 1, 0, 3
+	node_stack_back = 0.0, -5.0, -5.125, 0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10HalfFlightDeck.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10HalfFlightDeck.cfg
@@ -22,10 +22,10 @@ PART
 
 	// --- node definitions ---
 	node_stack_flightDeckMount = 0.0, 0.0, -5.0, 0, 0, 1, 3
-	node_stack_left = -5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_right = 5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_front = 0.0, 5, -5.125, 0, 0, -1, 3
-	node_stack_back = 0.0, -5, -5.125, 0, 0, -1, 3
+	node_stack_left = -5.0, 0.0, -5.125, -1, 0, 0, 3
+	node_stack_right = 5.0, 0.0, -5.125, 1, 0, 0, 3
+	node_stack_front = 0.0, 5.0, -5.125, 0, 1, 0, 3
+	node_stack_back = 0.0, -5.0, -5.125, 0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10HangarDeck.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10HangarDeck.cfg
@@ -21,15 +21,15 @@ PART
 	}
 
 	// --- node definitions ---
-	node_attach = 5, 0.0, 0.0, 1.0, 0.0, 0.0, 1
+	node_attach = 5.0, 0.0, 0.0, 1, 0, 0, 1
 	node_stack_top = 0.0, 0.0, -5.0, 0, 0, -1, 3
 	node_stack_bottom = 0.0, 0.0, 5.0, 0, 0, 1, 3
 	node_stack_left = -5.0, 0.0, 0.0, -1, 0, 0, 3
 	node_stack_right = 5.0, 0.0, 0.0, 1, 0, 0, 3
-	node_stack_front = 0.0, 5, 0.0, 0.0, 1.0, 0.0, 3
-	node_stack_back = 0.0, -5, 0.0, 0.0, -1.0, 0.0, 3
-	node_stack_front2 = 0.0, 5, 0.0, 0.0, -1.0, 0.0, 3
-	node_stack_back2 = 0.0, -5, 0.0, 0.0, -1.0, 0.0, 3
+	node_stack_front = 0.0, 5.0, 0.0, 0.0, 1, 0, 3
+	node_stack_back = 0.0, -5.0, 0.0, 0.0, -1, 0, 3
+	node_stack_front2 = 0.0, 5.0, 0.0, 0.0, -1, 0, 3
+	node_stack_back2 = 0.0, -5.0, 0.0, 0.0, -1, 0, 3
 
 	NODE
 	{

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10SideElevator.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10SideElevator.cfg
@@ -22,10 +22,10 @@ PART
 
 	// --- node definitions ---
 	node_stack_flightDeckMount = 0.0, 0.0, -5.0, 0, 0, 1, 3
-	node_stack_left = -5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_right = 5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_front = 0.0, 5, -5.125, 0, 0, -1, 3
-	node_stack_back = 0.0, -5, -5.125, 0, 0, -1, 3
+	node_stack_left = -5.0, 0.0, -5.125, -1, 0, 0, 3
+	node_stack_right = 5.0, 0.0, -5.125, 1, 0, 0, 3
+	node_stack_front = 0.0, 5, -5.125, 0, 1, 0, 3
+	node_stack_back = 0.0, -5, -5.125, 0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics

--- a/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10TopFlightDeck.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/FlightDeckSystem/hl10TopFlightDeck.cfg
@@ -22,10 +22,10 @@ PART
 
 	// --- node definitions ---
 	node_stack_flightDeckMount = 0.0, 0.0, -5.0, 0, 0, 1, 3
-	node_stack_left = -5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_right = 5.0, 0.0, -5.125, 0, 0, -1, 3
-	node_stack_front = 0.0, 5, -5.125, 0, 0, -1, 3
-	node_stack_back = 0.0, -5, -5.125, 0, 0, -1, 3
+	node_stack_left = -5.0, 0.0, -5.125, -1, 0, 0, 3
+	node_stack_right = 5.0, 0.0, -5.125, 1, 0, 0, 3
+	node_stack_front = 0.0, 5, -5.125, 0, 1, 0, 3
+	node_stack_back = 0.0, -5, -5.125, 0, -1, 0, 3
 
 	// --- editor parameters ---
 	TechRequired = advAerodynamics


### PR DESCRIPTION
Hi,

I had some problems while attaching the flight deck extensions to the normal flight deck parts. After looking into it, I found that all the nodes were pointing up. I don't know if that was intentional. Anyway, I've modified them so that they point outward from their respective parts.