### PR TITLE
Update tailConnectorC.cfg

### DIFF
--- a/GameData/WildBlueIndustries/Heisenberg/Parts/RescaledStock/tailConnectorC.cfg
+++ b/GameData/WildBlueIndustries/Heisenberg/Parts/RescaledStock/tailConnectorC.cfg
@@ -32,7 +32,7 @@ PART
 	tags = aero aircraft drag fligh plane stab stream
 	MODEL
 	{
-		model = Squad/Parts/Aero/cones/TailA
+		model = Squad/Parts/Aero/cones/Assets/TailA
 		scale = 1, 0.75, 1
 	}
 	MODULE


### PR DESCRIPTION
FIXES PartComplier error.

[LOG 22:51:32.336] PartLoader: Compiling Part 'WildBlueIndustries/Heisenberg/Parts/RescaledStock/tailConnectorC/airplaneTail2'
[ERR 22:51:32.340] PartCompiler: Cannot clone model 'Squad/Parts/Aero/cones/TailA' as model does not exist
[ERR 22:51:32.340] PartCompiler: Model was not compiled correctly
[ERR 22:51:32.340] PartCompiler: Cannot compile model
[ERR 22:51:32.340] PartCompiler: Cannot compile part