### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/WildBlueIndustries/Heisenberg/Airships.version
+++ b/GameData/WildBlueIndustries/Heisenberg/Airships.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Airships",
-    "URL":"https://raw.githubusercontent.com/Angel-125/Airships/master/GameData/WildBlueIndustries/Heisenberg/Airships/Airships.version",
+    "URL":"https://github.com/Angel-125/Airships/raw/master/GameData/WildBlueIndustries/Heisenberg/Airships.version",
     "DOWNLOAD":"https://github.com/Angel-125/Airships/releases",
     "GITHUB":
     {


### PR DESCRIPTION
It looks like #1 broke this property rather than fixing it. Or the file was moved? Either way, it's fixed now.

Tagging @Angel-125 to ensure GitHub sends a notification for this pull request.

@DasSkelett's https://github.com/DasSkelett/AVC-VersionFileValidator really is great! ;)