### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/WildBlueIndustries/Heisenberg/Airships.version
+++ b/GameData/WildBlueIndustries/Heisenberg/Airships.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Airships",
-    "URL":"https://raw.githubusercontent.com/Angel-125/Airships/master/GameData/WildBlueIndustries/Heisenberg/Airships/Airships.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/Airships/master/GameData/WildBlueIndustries/Heisenberg/Airships.version",
     "DOWNLOAD":"https://github.com/Angel-125/Airships/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125, there doesn't seem to be an `Airships` folder under `Heisenberg`.
Noticed while reviewing KSP-CKAN/NetKAN#10493.
Cheers!